### PR TITLE
Add dev startup commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 Mobile app to allow farmers and other food providers to notify the [Society of St. Andrew](endhunger.org) of food donations available for harvest and pick up.
 
 # Setup
+
+### Requirements 
+
+[node.js](https://nodejs.org/en/)
+
 ### Install dependencies
 `$ npm install`
 
@@ -12,9 +17,9 @@ Android - `android/app/google-services.json`
 
 # Development
 ### iOS
-You can launch the dev server for iOS with `react-native run-ios` or by running the project in XCode. [Docs](https://facebook.github.io/react-native/docs/running-on-simulator-ios)
+You can launch the dev server for iOS with `npm run dev:ios` or by running the project in XCode. [Docs](https://facebook.github.io/react-native/docs/running-on-simulator-ios)
 
 ### Android
-You can launch the dev server for Android with `react-native run-android`. A simulator will not open by default so you'll need to setup an Android simulator in Android Studio or use a tool like [Genymotion](https://www.genymotion.com/)
+You can launch the dev server for Android with `npm run dev:android`. A simulator will not open by default so you'll need to setup an Android simulator in Android Studio or use a tool like [Genymotion](https://www.genymotion.com/)
 
 You will also need Google Play Services installed and updated on the emulator.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "private": true,
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start",
-    "test": "jest"
+    "test": "jest",
+    "dev:ios": "react-native run-ios",
+    "dev:android": "react-native run-android"
   },
   "dependencies": {
     "react": "16.4.1",


### PR DESCRIPTION
The current setup requires `react-native` to be added globally. This PR adds:
- a requirements list (do we have a specific node version?) 
- two commands to call the local version of `react-native`